### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Build Docker Image
       run: docker build . --file Dockerfile --tag justinclayton/webwebweb
     - name: Publish To Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@2.14
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         # The name of the image you would like to push
         name: justinclayton/webwebweb


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore